### PR TITLE
Fixed problem with overlong command line.

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -135,7 +135,7 @@ $(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
-	+@echo "$(filter %.o, $^)" > .link_options.txt
+	$(file > .link_options.txt,$(filter %.o, $^)
 	+@echo "link: $(notdir $@)"
 	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}.link_options.txt $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}


### PR DESCRIPTION
### Description

The list of object files was so long, that it got truncated by the bash (git-bash).

Error was

    /usr/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
    /usr/bin/sh: -c: line 1: syntax error: unexpected end of file
    mingw32-make[1]: *** [Makefile:679: mbed-os-example-blinky-baremetal.elf] Error 1
    mingw32-make: *** [Makefile:26: all] Error 2

This may fix #10943

I fixed this problem using [this answer](https://stackoverflow.com/a/37506805/5534993).

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
